### PR TITLE
Bump glib version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 byteorder = "1"
 mpris-player = { git = "https://gitlab.gnome.org/World/Rust/mpris-player" }
-glib = "0.7"
+glib = "0.8"


### PR DESCRIPTION
https://gitlab.gnome.org/World/Rust/mpris-player/commit/e3ca52f3d013fa8fad1c230f2880a40bd099b0ce is causing this change to be required to build the server component.
This closes #3 